### PR TITLE
Adds playbook to install docker

### DIFF
--- a/docker.yml
+++ b/docker.yml
@@ -1,0 +1,9 @@
+# This playbook requires the angstwad.docker_ubuntu role
+# Install it with `ansible-galaxy install angstwad.docker_ubuntu`
+- name: Install Docker
+  hosts: docker
+  sudo: yes
+  vars:
+    update_docker_package: yes
+  roles:
+    - angstwad.docker_ubuntu

--- a/inventory
+++ b/inventory
@@ -20,3 +20,6 @@ web-prod10.igsp.duke.edu
 [cookie_dev_gcb]
 
 [cookie_prod_gcb]
+
+[docker]
+colab-sbx-58.oit.duke.edu


### PR DESCRIPTION
Uses docker_ubuntu role found in ansible galaxy.
Inventory is a single vm-manage node for testing